### PR TITLE
Change date format to make it parsable by javascript.

### DIFF
--- a/acmeair-jmeter/src/main/java/com/acmeair/jmeter/functions/GenerateDateFunction.java
+++ b/acmeair-jmeter/src/main/java/com/acmeair/jmeter/functions/GenerateDateFunction.java
@@ -41,7 +41,7 @@ public class GenerateDateFunction extends AbstractFunction {
 	public String execute(SampleResult arg0, Sampler arg1)
 			throws InvalidVariableException {
 		SimpleDateFormat date_format = new SimpleDateFormat(
-				"EEE MMM dd 00:00:00 z yyyy");
+				"EEE MMM dd 00:00:00 yyyy (z)");
 		if (parameters.get(0).execute().equalsIgnoreCase("from")) {
 			Calendar aDay = Calendar.getInstance();
 			aDay.add(Calendar.DATE, new Random().nextInt(6));


### PR DESCRIPTION
Running acmeair-nodejs I had the problem, that the the date genretated by __generateDate() can't be parsed by the javascript Date() constructor resulting in an undefined object. 
Running with mongodb the acmeair app doesn't complain about that. It simpy doesn't find any flights. Running with cassandra, the app procuces error messages. 
I changed the format in a way, that the string can be used in the Date constructor.

I only tested with acmeair-nodejs. I can't say, if it is still working with the java implementaion. 